### PR TITLE
MRG: add resources to Snakefile

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -184,9 +184,10 @@ rule metag_fastgather:
         db="interim/list.database-sketches.txt"
     output:
         "outputs/metag_gather/{name}.{k}.fastgather.csv",
+    threads: 64
     shell: """
         sourmash scripts fastgather {input.query} {input.db} -o {output} \
-           -k {wildcards.k}
+           -k {wildcards.k} -c {threads}
     """
 
 rule metag_gather:
@@ -197,6 +198,8 @@ rule metag_gather:
     output:
         csv=touch("outputs/metag_gather/{name}.{k}.gather.csv"),
         out="outputs/metag_gather/{name}.{k}.gather.txt",
+    resources:
+        gather=1
     shell: """
         sourmash gather {input.query} {input.db} -k {wildcards.k} \
             --picklist {input.fastgather_out}:match_md5:md5 \
@@ -257,12 +260,12 @@ rule metag_x_genomes_csv:
         genomes="interim/list.genome-sketches.{k}.txt",
     output:
         "outputs/metag.x.genomes.{k}.manysearch.csv"
-    threads: 64
+    threads: 8
     shell: """
         sourmash scripts manysearch -k {wildcards.k} \
             {input.genomes} {input.metag} \
             -c {threads} -t 0 \
-            -o {output}
+            -o {output} -c {threads}
     """
 
 rule summarize_manysearch:


### PR DESCRIPTION
even after fastgather, running multiple _gathers_ seems to be a problem - requiring ~30-60 GB of RAM each time. This PR adds threading resources as well as a `gather` resource. Will probably replace later with a mem resource instead.

A successful complete run used the following parameters:
```
srun -p high2 --time=72:00:00 --nodes=1 --cpus-per-task 128 --mem 120GB --pty bin/bash

snakemake --cores 128 --resources gather=2 -k
```