### PR TITLE
MRG: use manysketch for sketching

### DIFF
--- a/samples.csv
+++ b/samples.csv
@@ -1,4 +1,3 @@
 name,prefix
 metag_name_1,metag_1
-metag_name_1,metag_1
 metag_name_2,metag_2


### PR DESCRIPTION
This PR changes the sketching code to use `manysketch` instead of `sourmash sketch` for metagenomes - which will hopefully be (much) faster for annoyingly large metagenomes.

While simple in concept, this necessitates a lot of extra machinery 😅 :
* individual data files need to be sketched first
* then, these data files are combined

which OK sounds simple but involves quite a few extra steps in practice!

We also introduce a diagnostic computation that shows datafile membership in the final sketches, as a confirmation.

Fixes https://github.com/dib-lab/sourmash-slainte/issues/7