### PR TITLE
MRG: allow config to determine whether to run `gather` and `tax`

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -1,22 +1,12 @@
-import glob, os, csv
+import glob, csv
 from collections import defaultdict
+from slainte_functions import *
 
 configfile: "config.yml"
 
 wildcard_constraints:
     name='[^./]+',              # for 'name', don't recurse into subdirectories
     k = "\\d+",                 # for k-mer sizes, allow numbers only
-
-def strip_suffix(x):
-    "Remove standard DNA file suffixes to get the filename"
-    basename = os.path.basename(x)
-    while 1:
-        prefix, suffix = os.path.splitext(basename)
-        if suffix in ('.fa', '.fna', '.fasta', '.fq', '.fastq', '.gz', '.bz2'):
-            basename = prefix
-        else:
-            break
-    return basename
 
 # k-mer sizes to sketch:
 KSIZES = [21, 31, 51]
@@ -32,13 +22,7 @@ GATHER_KSIZE = 21
 # collect all genome files.
 #
 
-GENOME_NAMES = {}
-for g in config['genomes']:
-    files = glob.glob(g)
-    for filename in files:
-        name = strip_suffix(filename)
-        assert name not in GENOME_NAMES, f"duplicate prefix for {filename}"
-        GENOME_NAMES[name] = filename
+GENOME_NAMES = collect_genomes(config['genomes'])
 
 if len(GENOME_NAMES) > 0 and config['display_genomes']:
     ENABLE_GENOMES = True

--- a/Snakefile
+++ b/Snakefile
@@ -1,3 +1,4 @@
+# import utility functions:
 from slainte_functions import *
 
 configfile: "config.yml"
@@ -76,7 +77,6 @@ if RUN_GATHER:
     extra_outputs.extend(
         expand("outputs/metag_gather/metag.{k}.kreport.csv", k=GATHER_KSIZE),
         )
-
 
 rule all:
     input:

--- a/config.yml
+++ b/config.yml
@@ -2,11 +2,11 @@ metagenome_dir: data/metagenomes/
 
 sample_info: samples.csv
 
-display_genomes: False # for mkdocs, temporarily...
+display_genomes: True # for mkdocs, temporarily...
 genomes:
 - data/genomes/*.fa.gz
 
-run_gather: False
+run_gather: True
 
 databases:
 - ../sourmash/podar-ref.zip

--- a/config.yml
+++ b/config.yml
@@ -2,9 +2,11 @@ metagenome_dir: data/metagenomes/
 
 sample_info: samples.csv
 
-display_genomes: True # for mkdocs, temporarily...
+display_genomes: False # for mkdocs, temporarily...
 genomes:
 - data/genomes/*.fa.gz
+
+run_gather: False
 
 databases:
 - ../sourmash/podar-ref.zip

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,13 +11,17 @@ using [sourmash](https://sourmash.readthedocs.io/).
 [Metagenomes against genomes](metag_x_genomes.md) - which genomes are in which metagenomes?
 {% endif %}
 
+{% if run_gather %}
 [Metagenome taxonomy summary](metag_tax.md) - a taxonomic breakdown across all metagenomes.
+{% endif %}
 
 ---
 
 <!-- [Config / macros information](macros_info.md) -->
 
 ---
+
+{% if run_gather %}
 
 ## Databases and taxonomy
 
@@ -31,7 +35,15 @@ Taxonomy used for `sourmash tax metagenome`:
 * {{ tax }}
 {% endfor %}
 
+{% else %}
+
+No metagenome gather or taxonomic analysis is being performed;
+`run_gather` setting in `config.yml` is False.
+
+{% endif %}
+
 ## Sample information
 
 See the [sample x datafile](metag_sample_check.md) comparison for
 which samples contain which data.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,8 +42,7 @@ No metagenome gather or taxonomic analysis is being performed;
 
 {% endif %}
 
-## Sample information
+## Metagenome sample information
 
-See the [sample x datafile](metag_sample_check.md) comparison for
-which samples contain which data.
-
+See the [sample x datafile](metag_sample_check.md) comparison to
+verify which samples contain which data.

--- a/docs/metag_sample_check.md
+++ b/docs/metag_sample_check.md
@@ -1,0 +1,10 @@
+## Metagenome sample composition vis-a-vis raw data files
+
+This is a diagnostic check to confirm that the metagenome sample sketches
+are being constructed from the correct raw data files.
+
+This will be diagonal if each sample has one data file.
+
+### k=21
+
+[![](outputs/check/metag.x.individual.21.manysearch.png)](outputs/check/metag.x.individual.21.manysearch.png)

--- a/docs/metag_tax.md
+++ b/docs/metag_tax.md
@@ -1,10 +1,18 @@
 # Metagenome taxonomic summary
 
+{% if run_gather %}
+
 These tables are created by running `sourmash gather` followed by
 `sourmash tax metagenome` on each metagenome sample.
 
 ## Taxonomic summary
 
-{{ read_csv('outputs/metag_gather/metag.21.kreport.csv') }}
+{{ render_csv('outputs/metag_gather/metag.21.kreport.csv') }}
 
 [(Download CSV file)](outputs/metag_gather/metag.21.kreport.csv)
+
+{% else %}
+
+No taxonomic analysis run - `run_gather` is set to False in the config file.
+
+{% endif %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,8 +5,8 @@ theme:
 
 plugins:
 - search
-- table-reader
 - macros:
+     module_name: slainte_functions
      include_yaml:
        - config.yml
 markdown_extensions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-mkdocs-table-reader-plugin
 pymdown-extensions
 mkdocs-material
 mkdocs-material-extensions

--- a/slainte_functions.py
+++ b/slainte_functions.py
@@ -1,7 +1,10 @@
+# this module is used by both Snakefile and mkdocs-macros.
+# see 'define_env' for mkdocs-macros hook.
 import glob
 import os
 import csv
 from collections import defaultdict
+import pandas as pd
 
 
 __all__ = ['strip_suffix',
@@ -59,3 +62,18 @@ def load_metagenome_files(metag_path, samples_csv, debug=False):
                 METAGENOME_FILES[individual_name] = filename
 
     return METAGENOME_NAMES, METAGENOME_FILES
+
+
+def define_env(env):
+    "Hook function for mkdocs"
+
+    @env.macro
+    def render_csv(filename):
+        if os.path.exists(filename):
+            try:
+                df = pd.read_csv(filename)
+                return df.to_markdown()
+            except pd.errors.EmptyDataError:
+                pass
+
+        return ""

--- a/slainte_functions.py
+++ b/slainte_functions.py
@@ -1,0 +1,28 @@
+import glob
+import os
+
+__all__ = ['strip_suffix',
+           'collect_genomes']
+
+def strip_suffix(x):
+    "Remove standard DNA file suffixes to get the filename"
+    basename = os.path.basename(x)
+    while 1:
+        prefix, suffix = os.path.splitext(basename)
+        if suffix in ('.fa', '.fna', '.fasta', '.fq', '.fastq', '.gz', '.bz2'):
+            basename = prefix
+        else:
+            break
+    return basename
+
+def collect_genomes(genome_path):
+    genome_names = {}
+    for g in genome_path:
+        files = glob.glob(g)
+        for filename in files:
+            name = strip_suffix(filename)
+            assert name not in genome_names, f"duplicate prefix for {filename}"
+            genome_names[name] = filename
+
+    return genome_names
+


### PR DESCRIPTION
`run_gather` in the config file now determines if the gather & tax steps are run.

This PR also:
* moves most Python code from Snakefile to `slainte_functions.py`
* removes table-reader plugin and uses mkdocs-macro & pandas `to_markdown()` instead
